### PR TITLE
docs: add Versioning & Releases page for hardware modules

### DIFF
--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -48,8 +48,8 @@ flowchart TB
 
     AutoCalc[Diff seit letztem Release-Tag] --> Decide{Was hat sich geändert?}
     Decide -->|"nur Doku/CI"| NoTag[Kein Release nötig<br/>push:main hat Doku schon deployed]
-    Decide -->|"*.kicad_sch geändert"| Minor[gh release create<br/>v&lt;X&gt;.&lt;Y+1&gt;]
-    Decide -->|"*.kicad_pcb geändert"| Major[gh release create<br/>v&lt;X+1&gt;.0]
+    Decide -->|"nur *.kicad_sch geändert<br/>(PCB unverändert)"| Minor[gh release create<br/>v&lt;X&gt;.&lt;Y+1&gt;]
+    Decide -->|"*.kicad_pcb geändert<br/>(unabhängig vom Schaltplan)"| Major[gh release create<br/>v&lt;X+1&gt;.0]
     Minor --> Build1
     Major --> Build1
 ```
@@ -65,7 +65,7 @@ flowchart TB
 
 ### Auto-Release-Workflow (`workflow_dispatch`)
 
-- Trigger: Maintainer klickt im Modul-Repo unter „Actions" auf „Auto-Release" → „Run workflow".
+- Trigger: Maintainer klickt im Modul-Repo unter *Actions* auf *Auto-Release* → *Run workflow*.
 - Logik:
   1. Letzter Release-Tag wird ermittelt. Der Filter berücksichtigt nur Tags, die **dem Schema `v<MAJOR>.<MINOR>` folgen** *und* **deren MAJOR ≥ 1** ist. Pre-Scheme-Tags wie `v0.9` oder Beta-Tags fallen durch — selbst wenn sie syntaktisch passen, gelten sie als Pre-Baseline. Praktisch: das erste vom Workflow akzeptierte Release ist immer `v1.0`.
   2. Falls **kein** Release ≥ `v1.0` existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0 --generate-notes` erzeugt; danach pickt der Auto-Release-Workflow das auf.
@@ -85,9 +85,9 @@ flowchart TB
   4. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
   5. InvenTree-Update für die neue BOM **läuft als letzter Step und ist non-blocking** — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest (vor allem der Deploy) ist da schon durch. Reihenfolge bewusst so: ein InvenTree-Outage soll niemals das Release-Deploy blockieren.
 
-## PCB-Titelblock-Versions-Injection
+## Titelblock-Versions-Injection
 
-Jedes KiCad-Projekt enthält im Titelblock-Silkscreen den Platzhalter `<<VERSION>>` — je nach Modul im Schaltplan, im PCB oder in beidem (siehe `git grep '<<VERSION>>'` im jeweiligen Modul-Repo). Beim Build wird der Platzhalter ersetzt:
+Jedes KiCad-Projekt enthält im Titelblock den Platzhalter `<<VERSION>>` — je nach Modul im Schaltplan-Titelblock, im PCB-Titelblock (Silkscreen-Layer) oder in beidem (siehe `git grep '<<VERSION>>'` im jeweiligen Modul-Repo). Beim Build wird der Platzhalter ersetzt:
 
 | Trigger | Was wird in `<<VERSION>>` injiziert |
 | ------- | ----------------------------------- |
@@ -121,7 +121,7 @@ Regeln:
 
 ## Manuelle Releases / Tag-Pushes
 
-Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das nur GitHub-Actions (mit entsprechender Identität) erlaubt, Tags zu pushen. *(GitHub hat die alten „Tag Protection Rules" Ende 2024 durch Rulesets ersetzt.)*
+Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das nur GitHub-Actions (mit entsprechender Identität) erlaubt, Tags zu pushen. *(GitHub hat die alten Tag-Protection-Rules Ende 2024 durch Rulesets ersetzt.)*
 
 Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
 
@@ -134,13 +134,13 @@ Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
 
 Die Modul-Versionen sind **unabhängig** voneinander. PowerBoard `v1.5` und BusBoard `v2.0` haben keine implizite Kopplung — jedes Modul versioniert eigenständig.
 
-Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. *„PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Stromleitfähigkeit"*). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
+Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. *PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Stromleitfähigkeit*). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
 
 ## Firmware-Versionen
 
 Die STM32-Firmware im FM-Modul wird in einem **eigenen Repo** ([`FW-RemoteStation`](https://github.com/OE5XRX/FW-RemoteStation)) versioniert — ebenfalls Semver, aber **mit 3 Stellen** (`v1.2.3`), weil Firmware Patches anders behandelt als Hardware-Module.
 
-Bei Firmware-Releases, die ein bestimmtes Hardware-Modul nicht mehr unterstützen, wird das in den FM-Modul-Docs vermerkt (z.B. *„FW ≥ v2.0.0 setzt FM-Modul ≥ v1.5 voraus"*).
+Bei Firmware-Releases, die ein bestimmtes Hardware-Modul nicht mehr unterstützen, wird das in den FM-Modul-Docs vermerkt (z.B. *FW ≥ v2.0.0 setzt FM-Modul ≥ v1.5 voraus*).
 
 ## Operative Hinweise für Maintainer
 
@@ -162,7 +162,7 @@ Faustregeln — der Auto-Release-Workflow erkennt das alles automatisch, sie die
 
 ### Erste Releases
 
-Jedes Modul startet mit Tag `v1.0`, unabhängig davon welche älteren Tags davor existierten (frühere Tags bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf das `v<MAJOR>.<MINOR>`-Schema, sodass Pre-Scheme-Tags die Versions-Berechnung nicht durcheinander bringen). Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
+Jedes Modul startet mit Tag `v1.0`, unabhängig davon, welche älteren Tags davor existierten (frühere Tags bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf das `v<MAJOR>.<MINOR>`-Schema mit `MAJOR ≥ 1`, sodass Pre-Scheme-Tags die Versions-Berechnung nicht durcheinander bringen). Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
 
 ### Auf welcher Seite wird das jeweils sichtbar?
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -57,9 +57,9 @@ flowchart TB
 ### Push auf `main` (Doku-only Patches)
 
 - Trigger: `push: main` Event
-- Workflow: KiBot läuft (BOM/Gerbers/Renderings werden frisch erzeugt), `<<VERSION>>`-Platzhalter im PCB-Titelblock wird mit der **letzten Release-Tag-Version** befüllt, Jekyll baut die Doku, alles wird nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/` deployed.
+- Workflow: KiBot läuft (BOM/Gerbers/Renderings werden frisch erzeugt), `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit der **letzten Release-Tag-Version** befüllt, Jekyll baut die Doku, alles wird nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/` deployed.
 - **Kein** InvenTree-Update.
-- **Kein** Archive.
+- **Kein** Archive-Snapshot.
 
 > **Wichtige Annahme:** Dieser Pfad rebuildet auch dann, wenn der Push eine `.kicad_*`-Änderung enthält. Die Konvention im Repo ist, dass HW-Änderungen direkt vom Maintainer mit dem Auto-Release-Workflow nachgezogen werden — ansonsten zeigt die Live-Seite kurzzeitig den **neuen** Hardware-Stand mit dem **alten** Versions-Label aus dem Titelblock. Bewusst akzeptiert: für 5 Module mit niedriger Update-Frequenz und einem definierten Maintainer-Personenkreis ist die Reibung eines Release-Gates größer als das Risiko des kurzen Mismatches.
 
@@ -67,8 +67,8 @@ flowchart TB
 
 - Trigger: Maintainer klickt im Modul-Repo unter „Actions" auf „Auto-Release" → „Run workflow".
 - Logik:
-  1. Letzter Release-Tag wird ermittelt (`gh release list --limit 1`, gefiltert auf das `v<MAJOR>.<MINOR>`-Schema, sodass Pre-Scheme-Tags ignoriert werden).
-  2. Falls **kein** Release im Schema existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0` erzeugt; danach pickt der Auto-Release-Workflow das auf.
+  1. Letzter Release-Tag wird ermittelt. Der Filter berücksichtigt nur Tags, die **dem Schema `v<MAJOR>.<MINOR>` folgen** *und* **deren MAJOR ≥ 1** ist. Pre-Scheme-Tags wie `v0.9` oder Beta-Tags fallen durch — selbst wenn sie syntaktisch passen, gelten sie als Pre-Baseline. Praktisch: das erste vom Workflow akzeptierte Release ist immer `v1.0`.
+  2. Falls **kein** Release ≥ `v1.0` existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0 --generate-notes` erzeugt; danach pickt der Auto-Release-Workflow das auf.
   3. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
   4. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
   5. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
@@ -80,10 +80,10 @@ flowchart TB
 - Trigger: Auto-Release hat einen neuen Tag erzeugt.
 - Workflow:
   1. KiBot läuft (Production-Export).
-  2. `<<VERSION>>`-Platzhalter im PCB-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
-  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben).
-  4. InvenTree-Update für die neue BOM (non-blocking — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest geht durch).
-  5. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
+  2. `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
+  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben). Der Archive-Script ergänzt zusätzlich `nav_exclude: true` in den kopierten `*.md`-Front-Matter-Headern, damit die archivierten Seiten nicht im Just-the-docs Live-Nav als doppelte Einträge erscheinen — sie bleiben per Deep-Link erreichbar.
+  4. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
+  5. InvenTree-Update für die neue BOM **läuft als letzter Step und ist non-blocking** — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest (vor allem der Deploy) ist da schon durch. Reihenfolge bewusst so: ein InvenTree-Outage soll niemals das Release-Deploy blockieren.
 
 ## PCB-Titelblock-Versions-Injection
 
@@ -125,8 +125,10 @@ Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-
 
 Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
 
-1. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
-2. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
+1. **Voraussetzung:** Maintainer mit Repo-Admin-Rechten. Das Tag-Ruleset blockiert sonst auch maintainer-getriebene Tag-Operationen. Vor dem Rollback entweder das Tag-Ruleset unter *Settings → Rules* temporär deaktivieren, oder die eigene Identität in die `Bypass list` des Rulesets aufnehmen.
+2. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
+3. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
+4. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
 
 ## Cross-Repo-Kompatibilität
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -1,0 +1,165 @@
+---
+title: Versioning & Releases
+nav_order: 99
+parent: Hardware
+description: Versions-Schema, Release-Workflow und Archive-Strategie für die OE5XRX-Hardware-Module.
+---
+
+# Versioning & Releases
+
+Diese Seite beschreibt das Versions-Schema, den Release-Workflow und die Archive-Strategie der OE5XRX-Hardware-Module ([PowerBoard](./HW-Module-PowerBoard/), [BusBoard](./HW-Module-BusBoard/), [CM4 Carrier](./HW-Module-CM4Carrier/), [FM Transceiver](./HW-Module-FMTransceiver/), [DeviceTester](./HW-Module-DeviceTester/)).
+
+## Versions-Schema
+
+Jedes Modul verwendet **2-Level Semantic Versioning**: `v<MAJOR>.<MINOR>`. Es gibt **kein PATCH-Level**.
+
+| Bump | Was hat sich geändert | Beispiel |
+| ---- | --------------------- | -------- |
+| **MAJOR** (`v1.x → v2.0`) | PCB-Layout, Routing, Footprint-Änderung, Stecker-Pinout-Änderung — Hardware ist *nicht* abwärts-kompatibel | Re-Routing-Iteration, neuer Steckertyp |
+| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne Layout-Änderung, neue Variante, Pad-Korrekturen — BOM ändert sich, PCB-Layout bleibt stabil | LDO durch pin-kompatiblen Ersatztyp ersetzt |
+| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `.kicad_*` Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
+
+Die Bump-Entscheidung trifft ein **Auto-Release-Workflow** im jeweiligen Modul-Repo (per `workflow_dispatch` ausgelöst): er analysiert die Datei-Änderungen seit dem letzten Release-Tag und ermittelt den passenden Bump automatisch.
+
+## Release-Workflow
+
+```mermaid
+flowchart TB
+    Push[Developer push to main]
+    Disp[Maintainer löst<br/>Auto-Release-Workflow aus]
+
+    Push --> Build1
+    Disp --> AutoCalc
+
+    subgraph BuildPath [Build-and-Deploy]
+        direction TB
+        Build1[KiBot production export]
+        Build1 --> Stencil1[Stencil PNG]
+        Stencil1 --> Jekyll1[Jekyll build]
+        Jekyll1 --> CheckMajor{Major bump?}
+        CheckMajor -->|"yes (release event)"| Archive[Copy current<br/>/HW-Module-X/<br/>→ /HW-Module-X/v&lt;old&gt;/]
+        CheckMajor -->|"no"| Deploy1
+        Archive --> Deploy1[Deploy to canonical site<br/>/docs/.../HW-Module-X/]
+        Deploy1 --> InvenTree{release event?}
+        InvenTree -->|"yes"| InvenT[Update InvenTree<br/>non-blocking]
+        InvenTree -->|"no"| Done1([Done])
+        InvenT --> Done1
+    end
+
+    AutoCalc[Diff seit letztem Release-Tag] --> Decide{Was hat sich geändert?}
+    Decide -->|"nur Doku/CI"| NoTag[Kein Release nötig<br/>push:main hat Doku schon deployed]
+    Decide -->|"*.kicad_sch geändert"| Minor[gh release create<br/>v&lt;X&gt;.&lt;Y+1&gt;]
+    Decide -->|"*.kicad_pcb geändert"| Major[gh release create<br/>v&lt;X+1&gt;.0]
+    Minor --> Build1
+    Major --> Build1
+```
+
+### Push auf `main` (Doku-only Patches)
+
+- Trigger: `push: main` Event
+- Workflow: KiBot läuft (BOM/Gerbers/Renderings werden frisch erzeugt), `<<VERSION>>`-Platzhalter im PCB-Titelblock wird mit der **letzten Release-Tag-Version** befüllt, Jekyll baut die Doku, alles wird nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/` deployed.
+- **Kein** InvenTree-Update.
+- **Kein** Archive.
+
+### Auto-Release-Workflow (`workflow_dispatch`)
+
+- Trigger: Maintainer klickt im Modul-Repo unter „Actions" auf „Auto-Release" → „Run workflow".
+- Logik:
+  1. Letzter Release-Tag wird ermittelt (`gh release list --limit 1`).
+  2. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
+  3. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
+  4. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
+  5. Sonst → keine Tag-Erstellung (push:main hat die Doku schon deployed).
+  6. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes.
+
+### Release-Event (`release: published`)
+
+- Trigger: Auto-Release hat einen neuen Tag erzeugt.
+- Workflow:
+  1. KiBot läuft (Production-Export).
+  2. `<<VERSION>>`-Platzhalter im PCB-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
+  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Existiert die Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben).
+  4. InvenTree-Update für die neue BOM (non-blocking — falls InvenTree down ist, fehlschlägt nur dieser Step, der Rest geht durch).
+  5. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
+
+## PCB-Titelblock-Versions-Injection
+
+Jeder KiCad-Schaltplan enthält den Platzhalter `<<VERSION>>`. Beim Build wird der ersetzt mit einer reinen Semver-Zahl, ohne `v`-Prefix, ohne Git-SHA:
+
+| Trigger | Was wird in `<<VERSION>>` injiziert |
+| ------- | ----------------------------------- |
+| Tagged Release (`release: published`) | Tag-Name ohne `v`, z.B. `1.5` |
+| Push auf `main` (zwischen Releases) | Letzter Release-Tag ohne `v`, z.B. `1.5` |
+| Push auf `main` bevor je ein Release gemacht wurde | `pre-release` |
+
+Konsequenz: **das PCB zeigt die Hardware-Version**, nicht den momentanen Doku-Stand. Wenn du ein physisches PCB mit „1.5" gedruckt in der Hand hast, findest du den passenden Modul-Stand zur Hardware-Revision direkt:
+
+- Live-Doku passend zur Major-Version: `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`
+- Historische Major-Archive: `https://oe5xrx.org/docs/remote-station/hardware/<repo>/v1/`
+
+## Archive-Strategie
+
+Auf `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`:
+
+```
+docs/remote-station/hardware/HW-Module-PowerBoard/
+├── (aktueller Major, z.B. v2.x.y)
+├── v1/       ← Snapshot des letzten v1.x-Stands (eingefroren als v2.0 released wurde)
+└── v0/       ← Snapshot des letzten v0.x-Stands (falls je vorhanden)
+```
+
+Regeln:
+
+- Beim **Major-Bump** wird der aktuelle Stand snapshot-kopiert nach `/v<old-major>/`, bevor der neue Stand das Wurzelverzeichnis überschreibt.
+- Bei **Minor-Bumps** und **push:main** bleibt nur das Wurzelverzeichnis aktualisiert; vorhandene Archive bleiben unverändert.
+- Existiert der Archive-Pfad bereits, wird **nicht** überschrieben (Schutz vor versehentlichem Doppel-Trigger oder Re-Release).
+
+## Manuelle Releases / Tag-Pushes
+
+Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen**. Der Auto-Release-Workflow ist die einzige unterstützte Methode. Repository-Settings sollten Tag Protection Rules aktivieren, sodass nur GitHub-Actions (mit entsprechender Identität) Tags pushen können.
+
+Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken): manuelle Steps wie `gh release delete v2.0` und Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
+
+## Cross-Repo-Kompatibilität
+
+Die Modul-Versionen sind **unabhängig** voneinander. PowerBoard `v1.5` und BusBoard `v2.0` haben keine implizite Kopplung — jedes Modul versioniert eigenständig.
+
+Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. „PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Strom­leitfähigkeit"). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
+
+## Firmware-Versionen
+
+Die STM32-Firmware im FM-Modul wird in einem **eigenen Repo** ([`FW-RemoteStation`](https://github.com/OE5XRX/FW-RemoteStation)) versioniert — ebenfalls Semver, aber **mit 3 Stellen** (`v1.2.3`), weil Firmware Patches anders behandelt als Hardware-Module.
+
+Bei Firmware-Releases die ein bestimmtes Hardware-Modul nicht mehr unterstützen wird das in den FM-Modul-Docs vermerkt (z.B. „FW ≥ v2.0 setzt FM-Modul ≥ v1.5 voraus").
+
+## Operative Hinweise für Maintainer
+
+### Wann was bumpen?
+
+Faustregeln, von der Maschine eh automatisch erkannt aber zur Vorab-Orientierung:
+
+- **Ich möchte nur einen Tippfehler in der Doku fixen.**
+  → Push auf `main`. Auto-Deploy. Kein Release.
+
+- **Ich habe einen Kondensatortyp durch einen pin-kompatiblen Alternativ-Hersteller ersetzt.**
+  → `*.kicad_sch` ändert sich, `*.kicad_pcb` Layout bleibt. Auto-Release ergibt **Minor**.
+
+- **Ich habe das PCB neu geroutet (nach DRC-Cleanup, neuer Power-Plane).**
+  → `*.kicad_pcb` ändert sich. Auto-Release ergibt **Major**.
+
+- **Ich habe einen kosmetischen Silkscreen-Fix (z.B. Pin-1-Markierung) ohne Routing-Änderung gemacht.**
+  → `*.kicad_pcb` ändert sich minimal. Auto-Release-Action wird das als **Major** klassifizieren. Wenn das übertrieben ist, kannst du das Release manuell unterdrücken oder auch akzeptieren — Silkscreen-Änderungen erzeugen ja tatsächlich neue Gerber-Files für die Fertigung.
+
+### Erste Releases
+
+Jedes Modul startet mit Tag `v1.0`, unabhängig vom Modul-Stand der davor existierte (frühere Tags bleiben erhalten, werden aber nicht weiter gepflegt). Pro Modul entscheidet der Maintainer wann das erste `v1.0` released wird.
+
+### Auf welcher Seite wird das jeweils sichtbar?
+
+| Stelle | Was wird gezeigt |
+| ------ | ---------------- |
+| `oe5xrx.org/docs/remote-station/hardware/<repo>/` | Aktuelle Major-Version |
+| `oe5xrx.org/docs/remote-station/hardware/<repo>/v1/` etc. | Archivierte Major-Versionen |
+| `github.com/OE5XRX/<repo>/releases` | Alle bisherigen Tags + Release-Notes |
+| Auf dem physischen PCB (Titelblock) | Hardware-Version (Major.Minor, ohne v) |
+| InvenTree | BOM pro Release-Tag |

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -15,8 +15,8 @@ Jedes Modul verwendet **2-Level Semantic Versioning**: `v<MAJOR>.<MINOR>`. Es gi
 
 | Bump | Was hat sich geändert | Beispiel |
 | ---- | --------------------- | -------- |
-| **MAJOR** (`v1.x → v2.0`) | PCB-Layout, Routing, Footprint-Änderung, Stecker-Pinout-Änderung — Hardware ist *nicht* abwärts-kompatibel | Re-Routing-Iteration, neuer Steckertyp |
-| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne Layout-Änderung, neue Variante, Pad-Korrekturen — BOM ändert sich, PCB-Layout bleibt stabil | LDO durch pin-kompatiblen Ersatztyp ersetzt |
+| **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` ändert sich — egal ob Re-Routing, Footprint-Tausch, Pad-Korrektur, Silkscreen-Fix oder Stecker-Pinout. Sobald sich am PCB ein Byte ändert, wird ein neuer Gerber-Satz fertigbar — also Major. | Re-Routing-Iteration, neuer Steckertyp, Pin-1-Markierung verschoben |
+| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne PCB-Layout-Änderung — `*.kicad_sch` ändert sich, `*.kicad_pcb` bleibt **byte-identisch**. BOM und Schaltplan dürfen sich ändern. | LDO durch pin-kompatiblen Ersatztyp ersetzt |
 | **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `.kicad_*` Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
 
 Die Bump-Entscheidung trifft ein **Auto-Release-Workflow** im jeweiligen Modul-Repo (per `workflow_dispatch` ausgelöst): er analysiert die Datei-Änderungen seit dem letzten Release-Tag und ermittelt den passenden Bump automatisch.
@@ -37,7 +37,7 @@ flowchart TB
         Build1 --> Stencil1[Stencil PNG]
         Stencil1 --> Jekyll1[Jekyll build]
         Jekyll1 --> CheckMajor{Major bump?}
-        CheckMajor -->|"yes (release event)"| Archive[Copy current<br/>/HW-Module-X/<br/>→ /HW-Module-X/v&lt;old&gt;/]
+        CheckMajor -->|"yes (release event)"| Archive[Copy current<br/>/HW-Module-X/<br/>→ /HW-Module-X/v&lt;old-major&gt;/<br/>excluding existing v*/ subdirs]
         CheckMajor -->|"no"| Deploy1
         Archive --> Deploy1[Deploy to canonical site<br/>/docs/.../HW-Module-X/]
         Deploy1 --> InvenTree{release event?}
@@ -61,16 +61,19 @@ flowchart TB
 - **Kein** InvenTree-Update.
 - **Kein** Archive.
 
+> **Wichtige Annahme:** Dieser Pfad rebuildet auch dann, wenn der Push eine `.kicad_*`-Änderung enthält. Die Konvention im Repo ist, dass HW-Änderungen direkt vom Maintainer mit dem Auto-Release-Workflow nachgezogen werden — ansonsten zeigt die Live-Seite kurzzeitig den **neuen** Hardware-Stand mit dem **alten** Versions-Label aus dem Titelblock. Bewusst akzeptiert: für 5 Module mit niedriger Update-Frequenz und einem definierten Maintainer-Personenkreis ist die Reibung eines Release-Gates größer als das Risiko des kurzen Mismatches.
+
 ### Auto-Release-Workflow (`workflow_dispatch`)
 
 - Trigger: Maintainer klickt im Modul-Repo unter „Actions" auf „Auto-Release" → „Run workflow".
 - Logik:
-  1. Letzter Release-Tag wird ermittelt (`gh release list --limit 1`).
-  2. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
-  3. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
-  4. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
-  5. Sonst → keine Tag-Erstellung (push:main hat die Doku schon deployed).
-  6. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes.
+  1. Letzter Release-Tag wird ermittelt (`gh release list --limit 1`, gefiltert auf das `v<MAJOR>.<MINOR>`-Schema, sodass Pre-Scheme-Tags ignoriert werden).
+  2. Falls **kein** Release im Schema existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0` erzeugt; danach pickt der Auto-Release-Workflow das auf.
+  3. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
+  4. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
+  5. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
+  6. Sonst → keine Tag-Erstellung (push:main hat die Doku schon deployed).
+  7. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes.
 
 ### Release-Event (`release: published`)
 
@@ -78,24 +81,26 @@ flowchart TB
 - Workflow:
   1. KiBot läuft (Production-Export).
   2. `<<VERSION>>`-Platzhalter im PCB-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
-  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Existiert die Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben).
-  4. InvenTree-Update für die neue BOM (non-blocking — falls InvenTree down ist, fehlschlägt nur dieser Step, der Rest geht durch).
+  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben).
+  4. InvenTree-Update für die neue BOM (non-blocking — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest geht durch).
   5. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
 
 ## PCB-Titelblock-Versions-Injection
 
-Jeder KiCad-Schaltplan enthält den Platzhalter `<<VERSION>>`. Beim Build wird der ersetzt mit einer reinen Semver-Zahl, ohne `v`-Prefix, ohne Git-SHA:
+Jedes KiCad-Projekt enthält im Titelblock-Silkscreen den Platzhalter `<<VERSION>>` — je nach Modul im Schaltplan, im PCB oder in beidem (siehe `git grep '<<VERSION>>'` im jeweiligen Modul-Repo). Beim Build wird der Platzhalter ersetzt:
 
 | Trigger | Was wird in `<<VERSION>>` injiziert |
 | ------- | ----------------------------------- |
-| Tagged Release (`release: published`) | Tag-Name ohne `v`, z.B. `1.5` |
-| Push auf `main` (zwischen Releases) | Letzter Release-Tag ohne `v`, z.B. `1.5` |
-| Push auf `main` bevor je ein Release gemacht wurde | `pre-release` |
+| Tagged Release (`release: published`) | Tag-Name ohne `v`-Prefix, z.B. `1.5` |
+| Push auf `main` (zwischen Releases) | Letzter Release-Tag ohne `v`-Prefix, z.B. `1.5` |
+| Push auf `main` bevor je ein Release gemacht wurde | Literal `pre-release` (Ausnahme: nicht semver-konform; markiert nur den Bootstrap-Zustand vor dem ersten `v1.0`) |
 
-Konsequenz: **das PCB zeigt die Hardware-Version**, nicht den momentanen Doku-Stand. Wenn du ein physisches PCB mit „1.5" gedruckt in der Hand hast, findest du den passenden Modul-Stand zur Hardware-Revision direkt:
+Konsequenz: **das PCB zeigt die Hardware-Version**, nicht den momentanen Doku-Stand. Wenn du ein physisches PCB mit `1.5` gedruckt in der Hand hast, findest du den passenden Modul-Stand zur Hardware-Revision so:
 
-- Live-Doku passend zur Major-Version: `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`
-- Historische Major-Archive: `https://oe5xrx.org/docs/remote-station/hardware/<repo>/v1/`
+- Falls `1.5` zur **aktuell** auf der Webseite veröffentlichten Major-Version (`v1.x`) gehört → kanonische Doku unter `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
+- Falls `1.5` zu einer **älteren** Major-Version gehört (z.B. live ist v2 oder neuer) → Archiv-Doku unter `https://oe5xrx.org/docs/remote-station/hardware/<repo>/v1/`.
+
+Die kanonische URL zeigt also **immer den aktuellen Major** — historische Hardware findet sich in den `v<old-major>/`-Archiven.
 
 ## Archive-Strategie
 
@@ -103,56 +108,59 @@ Auf `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`:
 
 ```
 docs/remote-station/hardware/HW-Module-PowerBoard/
-├── (aktueller Major, z.B. v2.x.y)
+├── (aktueller Major, z.B. v2.x)
 ├── v1/       ← Snapshot des letzten v1.x-Stands (eingefroren als v2.0 released wurde)
 └── v0/       ← Snapshot des letzten v0.x-Stands (falls je vorhanden)
 ```
 
 Regeln:
 
-- Beim **Major-Bump** wird der aktuelle Stand snapshot-kopiert nach `/v<old-major>/`, bevor der neue Stand das Wurzelverzeichnis überschreibt.
+- Beim **Major-Bump** wird der aktuelle Stand snapshot-kopiert nach `/v<old-major>/`, bevor der neue Stand das Wurzelverzeichnis überschreibt. Bestehende `v*/`-Unterordner sind vom Snapshot ausgeschlossen.
 - Bei **Minor-Bumps** und **push:main** bleibt nur das Wurzelverzeichnis aktualisiert; vorhandene Archive bleiben unverändert.
 - Existiert der Archive-Pfad bereits, wird **nicht** überschrieben (Schutz vor versehentlichem Doppel-Trigger oder Re-Release).
 
 ## Manuelle Releases / Tag-Pushes
 
-Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen**. Der Auto-Release-Workflow ist die einzige unterstützte Methode. Repository-Settings sollten Tag Protection Rules aktivieren, sodass nur GitHub-Actions (mit entsprechender Identität) Tags pushen können.
+Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das nur GitHub-Actions (mit entsprechender Identität) erlaubt, Tags zu pushen. *(GitHub hat die alten „Tag Protection Rules" Ende 2024 durch Rulesets ersetzt.)*
 
-Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken): manuelle Steps wie `gh release delete v2.0` und Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
+Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
+
+1. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
+2. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
 
 ## Cross-Repo-Kompatibilität
 
 Die Modul-Versionen sind **unabhängig** voneinander. PowerBoard `v1.5` und BusBoard `v2.0` haben keine implizite Kopplung — jedes Modul versioniert eigenständig.
 
-Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. „PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Strom­leitfähigkeit"). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
+Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. *„PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Stromleitfähigkeit"*). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
 
 ## Firmware-Versionen
 
 Die STM32-Firmware im FM-Modul wird in einem **eigenen Repo** ([`FW-RemoteStation`](https://github.com/OE5XRX/FW-RemoteStation)) versioniert — ebenfalls Semver, aber **mit 3 Stellen** (`v1.2.3`), weil Firmware Patches anders behandelt als Hardware-Module.
 
-Bei Firmware-Releases die ein bestimmtes Hardware-Modul nicht mehr unterstützen wird das in den FM-Modul-Docs vermerkt (z.B. „FW ≥ v2.0 setzt FM-Modul ≥ v1.5 voraus").
+Bei Firmware-Releases, die ein bestimmtes Hardware-Modul nicht mehr unterstützen, wird das in den FM-Modul-Docs vermerkt (z.B. *„FW ≥ v2.0.0 setzt FM-Modul ≥ v1.5 voraus"*).
 
 ## Operative Hinweise für Maintainer
 
 ### Wann was bumpen?
 
-Faustregeln, von der Maschine eh automatisch erkannt aber zur Vorab-Orientierung:
+Faustregeln — der Auto-Release-Workflow erkennt das alles automatisch, sie dienen nur zur Vorab-Orientierung:
 
 - **Ich möchte nur einen Tippfehler in der Doku fixen.**
   → Push auf `main`. Auto-Deploy. Kein Release.
 
 - **Ich habe einen Kondensatortyp durch einen pin-kompatiblen Alternativ-Hersteller ersetzt.**
-  → `*.kicad_sch` ändert sich, `*.kicad_pcb` Layout bleibt. Auto-Release ergibt **Minor**.
+  → `*.kicad_sch` ändert sich, `*.kicad_pcb` Layout bleibt byte-identisch. Auto-Release ergibt **Minor**.
 
 - **Ich habe das PCB neu geroutet (nach DRC-Cleanup, neuer Power-Plane).**
   → `*.kicad_pcb` ändert sich. Auto-Release ergibt **Major**.
 
-- **Ich habe einen kosmetischen Silkscreen-Fix (z.B. Pin-1-Markierung) ohne Routing-Änderung gemacht.**
-  → `*.kicad_pcb` ändert sich minimal. Auto-Release-Action wird das als **Major** klassifizieren. Wenn das übertrieben ist, kannst du das Release manuell unterdrücken oder auch akzeptieren — Silkscreen-Änderungen erzeugen ja tatsächlich neue Gerber-Files für die Fertigung.
+- **Ich habe einen kosmetischen Silkscreen-Fix (z.B. Pin-1-Markierung) gemacht.**
+  → `*.kicad_pcb` ändert sich (Silkscreen-Layer ist Teil der Gerber-Daten). Auto-Release ergibt **Major** — und das ist auch richtig so: für die Fertigung ändert sich der Datensatz, der ans PCB-House geht. Lass das Release durch.
 
 ### Erste Releases
 
-Jedes Modul startet mit Tag `v1.0`, unabhängig vom Modul-Stand der davor existierte (frühere Tags bleiben erhalten, werden aber nicht weiter gepflegt). Pro Modul entscheidet der Maintainer wann das erste `v1.0` released wird.
+Jedes Modul startet mit Tag `v1.0`, unabhängig davon welche älteren Tags davor existierten (frühere Tags bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf das `v<MAJOR>.<MINOR>`-Schema, sodass Pre-Scheme-Tags die Versions-Berechnung nicht durcheinander bringen). Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
 
 ### Auf welcher Seite wird das jeweils sichtbar?
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -9,17 +9,24 @@ description: Versions-Schema, Release-Workflow und Archive-Strategie für die OE
 
 Diese Seite beschreibt das Versions-Schema, den Release-Workflow und die Archive-Strategie der OE5XRX-Hardware-Module ([PowerBoard](./HW-Module-PowerBoard/), [BusBoard](./HW-Module-BusBoard/), [CM4 Carrier](./HW-Module-CM4Carrier/), [FM Transceiver](./HW-Module-FMTransceiver/), [DeviceTester](./HW-Module-DeviceTester/)).
 
+> **Status (Mai 2026): Konzept — Implementierung in Arbeit.** Diese Seite dokumentiert das geplante Verhalten. Phase 1 (diese Doku) ist live. Der `<<VERSION>>`-Platzhalter (Phase 2-3) ist in [`HW-Module-CI`](https://github.com/OE5XRX/HW-Module-CI) und den fünf Modul-Repos eingezogen. Der Auto-Release-Workflow (Phase 4-5) und die ersten `v1.0`-Releases (Phase 7) folgen — bis dahin behandelt CI jeden `push: main` als Doku-Update mit injiziertem `pre-release`-Label. Maintainer **nicht** vor Phase 7 ein Tag-Ruleset aktivieren (Phase 6), das blockt sonst den manuellen `v1.0`-Bootstrap.
+
 ## Versions-Schema
 
 Jedes Modul verwendet **2-Level Semantic Versioning**: `v<MAJOR>.<MINOR>`. Es gibt **kein PATCH-Level**.
 
 | Bump | Was hat sich geändert | Beispiel |
 | ---- | --------------------- | -------- |
-| **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` ändert sich — egal ob Re-Routing, Footprint-Tausch, Pad-Korrektur, Silkscreen-Fix oder Stecker-Pinout. Sobald sich am PCB ein Byte ändert, wird ein neuer Gerber-Satz fertigbar — also Major. | Re-Routing-Iteration, neuer Steckertyp, Pin-1-Markierung verschoben |
-| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne PCB-Layout-Änderung — `*.kicad_sch` ändert sich, `*.kicad_pcb` bleibt **byte-identisch**. BOM und Schaltplan dürfen sich ändern. | LDO durch pin-kompatiblen Ersatztyp ersetzt |
-| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `*.kicad_*` Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
+| **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` ändert sich im Source — egal ob Re-Routing, Footprint-Tausch, Pad-Korrektur, Silkscreen-Fix oder Stecker-Pinout. Sobald sich am PCB ein Byte ändert, wird ein neuer Gerber-Satz fertigbar — also Major. | Re-Routing-Iteration, neuer Steckertyp, Pin-1-Markierung verschoben |
+| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne PCB-Layout-Änderung — `*.kicad_sch` ändert sich, `*.kicad_pcb` bleibt im Source **byte-identisch**. BOM und Schaltplan dürfen sich ändern. | LDO durch pin-kompatiblen Ersatztyp ersetzt |
+| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `*.kicad_pcb`/`*.kicad_sch`-Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
 
 Die Bump-Entscheidung trifft ein **Auto-Release-Workflow** im jeweiligen Modul-Repo (per `workflow_dispatch` ausgelöst): er analysiert die Datei-Änderungen seit dem letzten Release-Tag und ermittelt den passenden Bump automatisch.
+
+> **Hinweise zum „Byte-Identisch"-Kriterium:**
+>
+> - Nur `*.kicad_pcb` und `*.kicad_sch` zählen für die Bump-Entscheidung. Andere KiCad-Projektdateien (`*.kicad_pro`, `*.kicad_prl`, `fp-info-cache`, `sym-lib-table`) werden vom Workflow ignoriert — sie betreffen nur die Entwicklungs-Sicht, nicht das Fertigungspaket.
+> - Die `<<VERSION>>`-Substitution durch CI passiert auf den **Build-Output-Files** (kopierte temporäre Files vor KiBot), niemals auf den Sources. Der Source-`.kicad_pcb` im Repo behält immer den Literal `<<VERSION>>`. Das heißt: eine reine Versions-Label-Änderung ändert weder das Source-PCB noch löst sie einen falschen Major-Bump aus.
 
 ## Release-Workflow
 
@@ -54,9 +61,9 @@ flowchart TB
     Major --> Build1
 ```
 
-### Push auf `main` (Doku-only Patches)
+### Push auf `main` (Doku-Deploy)
 
-- Trigger: `push: main` Event
+- Trigger: `push: main` Event (jeder Push, egal welche Files geändert wurden)
 - Workflow: KiBot läuft (BOM/Gerbers/Renderings werden frisch erzeugt), `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit der **letzten Release-Tag-Version** befüllt, Jekyll baut die Doku, alles wird nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/` deployed.
 - **Kein** InvenTree-Update.
 - **Kein** Archive-Snapshot.
@@ -80,7 +87,7 @@ flowchart TB
 
 ### Release-Event (`release: published`)
 
-- Trigger: Auto-Release hat einen neuen Tag erzeugt.
+- Trigger: jeder neue Release im Modul-Repo — sowohl die vom Auto-Release-Workflow erzeugten Tags **als auch** der manuelle `v1.0`-Bootstrap-Release. Beide Pfade laufen denselben Build-and-Deploy-Code, sodass auch die initiale `v1.0` die dokumentierte Versions-Injection und den Deploy-Pfad erhält.
 - Workflow:
   1. KiBot läuft (Production-Export).
   2. `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
@@ -124,15 +131,20 @@ Regeln:
 
 ## Manuelle Releases / Tag-Pushes
 
-Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das nur GitHub-Actions (mit entsprechender Identität) erlaubt, Tags zu pushen. *(GitHub hat die alten Tag-Protection-Rules Ende 2024 durch Rulesets ersetzt.)*
+Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das Tag-Pushes nur für **die konkrete Identität erlaubt, unter der `gh release create` im Auto-Release-Workflow läuft** — also typischerweise der PAT-Owner oder die GitHub-App-Installation, deren Token in den Org-Secrets liegt. Eine generische „GitHub Actions" Allow-Rule reicht nicht, weil der PAT-Push als Identität des PAT-Owners zählt, nicht als Bot. *(GitHub hat die alten Tag-Protection-Rules Ende 2024 durch Rulesets ersetzt.)*
+
+> **Reihenfolge wichtig:** Das Tag-Ruleset **erst nach dem manuellen `v1.0`-Bootstrap** aktivieren (Phase 6 nach Phase 7). Ein vorher aktiviertes Ruleset blockt sonst den Bootstrap-Push selbst. Für etwaige spätere `v1.0`-Bootstraps weiterer Module gilt: vorher das Ruleset temporär deaktivieren oder die eigene Identität in die `Bypass list` aufnehmen.
 
 Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
 
 1. **Voraussetzung:** Maintainer mit Repo-Admin-Rechten. Das Tag-Ruleset blockiert sonst auch maintainer-getriebene Tag-Operationen. Vor dem Rollback entweder das Tag-Ruleset unter *Settings → Rules* temporär deaktivieren, oder die eigene Identität in die `Bypass list` des Rulesets aufnehmen.
 2. **Source-Stand bereinigen:** der Commit, der den fehlerhaften Release ausgelöst hat, muss im Modul-Repo auf `main` zurückgenommen werden (`git revert <bad-sha>` und push, oder `git reset --hard <good-sha>` + force-push, je nach Situation). Wird das übersprungen, redeployed der nächste `push: main` denselben Bad State unter dem alten Versions-Label — und ein erneuter Auto-Release-Run würde wieder dieselbe defekte Version produzieren.
-3. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
-4. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
-5. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
+3. Release **und** Git-Tag löschen:
+    - Falls ein Release-Objekt existiert: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag entfernt zusätzlich den Git-Tag — ohne den Flag bleibt der Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
+    - Falls **nur** ein raw Git-Tag existiert (z.B. Legacy-`v1.x`-Cleanup vor dem Bootstrap, hier ohne zugehörigen GitHub-Release): `git tag -d v2.0 && git push origin :refs/tags/v2.0`. `gh release delete` schlägt sonst mit „release not found" fehl.
+4. **Failed-Archive löschen:** falls beim Major-Bump-Versuch bereits ein `/v<failed-major>/`-Snapshot angelegt wurde, diesen vor dem Restore entfernen — sonst überspringt der nächste Versuch das Archive (Existence-Guard) und das Wurzelverzeichnis bekommt keinen sauberen Vorgänger-Snapshot.
+5. **Restore:** Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v<good-major>/` per `git` im OE5XRX.github.io-Repo. Beim Promoten zurück zur Live-Position das `nav_exclude: true` aus den `*.md`-Front-Matter-Headern entfernen — sonst ist die wiederhergestellte Doku zwar live, aber nicht im Just-the-docs Nav-Tree sichtbar.
+6. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
 
 ## Cross-Repo-Kompatibilität
 
@@ -166,7 +178,12 @@ Faustregeln — der Auto-Release-Workflow erkennt das alles automatisch, sie die
 
 ### Erste Releases
 
-Jedes Modul startet mit Tag `v1.0`. Pre-Scheme-Tags im `v0.x`- oder Beta-Bereich bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf `MAJOR ≥ 1` und überspringt sie. Sollte ein Modul **bereits** Legacy-`v1.x`-Tags von vor dieser Konvention haben, gibt es zwei Optionen: (a) die Legacy-Tags vor dem Bootstrap löschen (`gh release delete <tag> --cleanup-tag`), oder (b) den nächsten Tag manuell auf den nächsten freien `v<MAJOR>.<MINOR>`-Slot setzen und den Auto-Release ab da weiterzählen lassen. Für die OE5XRX-Module wurde vor Rollout verifiziert, dass keine Legacy-`v1.x`-Tags existieren. Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
+Jedes Modul startet mit Tag `v1.0`. Pre-Scheme-Tags im `v0.x`- oder Beta-Bereich bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf `MAJOR ≥ 1` und überspringt sie. Sollte ein Modul **bereits** Legacy-`v1.x`-Tags von vor dieser Konvention haben, gibt es zwei Optionen:
+
+- **(a) Legacy-Tags vor dem Bootstrap löschen.** Wenn zum Tag ein GitHub-Release existiert: `gh release delete <tag> --cleanup-tag`. Wenn es nur einen raw Git-Tag ohne Release-Objekt gibt: `git tag -d <tag> && git push origin :refs/tags/<tag>` — `gh release delete` schlägt sonst mit „release not found" fehl.
+- **(b) Den ersten Bootstrap-Tag auf den nächsten freien `v<MAJOR>.<MINOR>`-Slot setzen** und den Auto-Release ab da weiterzählen lassen.
+
+Für die OE5XRX-Module wurde vor Rollout verifiziert, dass keine Legacy-`v1.x`-Tags existieren. Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Das Tag-Ruleset darf zu diesem Zeitpunkt **nicht** aktiv sein, sonst blockt es den Bootstrap-Push (siehe „Manuelle Releases / Tag-Pushes" oben). Nach dem ersten Release übernimmt der Auto-Release-Workflow.
 
 ### Auf welcher Seite wird das jeweils sichtbar?
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -19,11 +19,11 @@ Jedes Modul nutzt `v<MAJOR>.<MINOR>` — bewusst nur 2 Stellen, kein Patch-Level
 | **MINOR** (`v1.0 → v1.1`) | Nur `*.kicad_sch` ändert sich, PCB-Layout bleibt | LDO durch pin-kompatiblen Ersatz |
 | **kein Release** | Nur Doku, README, CI | Tippfehler in einer `index.md` |
 
-Faustregel: sobald das PCB ein neues Gerber-File produziert, ist das ein Major. Alles andere ist Minor oder „nur Doku".
+Faustregel: sobald das PCB ein neues Gerber-File produziert, ist das ein Major. Alles andere ist Minor oder *nur Doku*.
 
 ## Wie kommt ein Release zustande?
 
-1. Maintainer pusht seine Änderungen auf `main`. Jeder Push deployed automatisch die Doku samt frischer Renderings nach [oe5xrx.org/docs/remote-station/hardware/<repo>/](https://oe5xrx.org/docs/remote-station/hardware/).
+1. Maintainer pusht seine Änderungen auf `main`. Jeder Push deployed automatisch die Doku samt frischer Renderings unter `oe5xrx.org/docs/remote-station/hardware/<repo>/` — eine Übersicht aller Modul-Pages liegt auf der [Hardware-Seite](../).
 2. Will der Maintainer einen echten Release, startet er im Modul-Repo den **Auto-Release-Workflow** (per *Actions* → *Auto-Release* → *Run workflow*). Der schaut sich den Diff seit dem letzten Release an, entscheidet Major/Minor/kein Release nach der Tabelle oben und erstellt den passenden Tag plus Release-Notes.
 3. Beim neuen Release läuft KiBot, ein BOM-Sync zu InvenTree, und die fertigen Artefakte ersetzen den bisherigen Live-Stand auf der Webseite.
 
@@ -39,7 +39,7 @@ flowchart LR
 
 ## Versions-Label am PCB
 
-Im KiCad-Titelblock steht der Platzhalter `<<VERSION>>`. Den ersetzt CI beim Build mit der Versionsnummer (`1.5`, ohne `v`-Prefix). Damit zeigt jedes physische PCB seine Hardware-Revision. Hat man so ein Board in der Hand, weiß man sofort welcher Doku-Stand passt:
+Im KiCad-Titelblock steht der Platzhalter `<<VERSION>>`. Den ersetzt CI beim Build mit der Versionsnummer (`1.5`, ohne `v`-Prefix). Damit zeigt jedes physische PCB seine Hardware-Revision. Hat man so ein Board in der Hand, weiß man sofort, welcher Doku-Stand passt:
 
 - **Aktueller Major** → kanonische Doku unter `oe5xrx.org/docs/remote-station/hardware/<repo>/`
 - **Älterer Major** → archivierte Doku unter `…/<repo>/v1/`, `…/<repo>/v0/` etc.
@@ -48,7 +48,7 @@ Im KiCad-Titelblock steht der Platzhalter `<<VERSION>>`. Den ersetzt CI beim Bui
 
 Beim Major-Bump (z.B. `v1.x → v2.0`) verschiebt CI den bisherigen `/<repo>/`-Inhalt auf `/<repo>/v1/`. Danach landet der neue v2-Stand im Wurzelverzeichnis. Minor-Bumps und reine Doku-Pushes lassen die Archive in Ruhe.
 
-Konsequenz: die aktuelle Major-Version ist immer einen Klick weniger entfernt; ältere Hardware-Revisionen bleiben aber dauerhaft erreichbar — wichtig, wenn jemand ein „altes" Board aus dem Schrank holt.
+Konsequenz: die aktuelle Major-Version ist immer einen Klick weniger entfernt; ältere Hardware-Revisionen bleiben aber dauerhaft erreichbar — wichtig, wenn jemand ein *altes* Board aus dem Schrank holt.
 
 ## Cross-Repo-Kompatibilität
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -17,7 +17,7 @@ Jedes Modul verwendet **2-Level Semantic Versioning**: `v<MAJOR>.<MINOR>`. Es gi
 | ---- | --------------------- | -------- |
 | **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` ändert sich — egal ob Re-Routing, Footprint-Tausch, Pad-Korrektur, Silkscreen-Fix oder Stecker-Pinout. Sobald sich am PCB ein Byte ändert, wird ein neuer Gerber-Satz fertigbar — also Major. | Re-Routing-Iteration, neuer Steckertyp, Pin-1-Markierung verschoben |
 | **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne PCB-Layout-Änderung — `*.kicad_sch` ändert sich, `*.kicad_pcb` bleibt **byte-identisch**. BOM und Schaltplan dürfen sich ändern. | LDO durch pin-kompatiblen Ersatztyp ersetzt |
-| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `.kicad_*` Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
+| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `*.kicad_*` Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
 
 Die Bump-Entscheidung trifft ein **Auto-Release-Workflow** im jeweiligen Modul-Repo (per `workflow_dispatch` ausgelöst): er analysiert die Datei-Änderungen seit dem letzten Release-Tag und ermittelt den passenden Bump automatisch.
 
@@ -61,19 +61,22 @@ flowchart TB
 - **Kein** InvenTree-Update.
 - **Kein** Archive-Snapshot.
 
-> **Wichtige Annahme:** Dieser Pfad rebuildet auch dann, wenn der Push eine `.kicad_*`-Änderung enthält. Die Konvention im Repo ist, dass HW-Änderungen direkt vom Maintainer mit dem Auto-Release-Workflow nachgezogen werden — ansonsten zeigt die Live-Seite kurzzeitig den **neuen** Hardware-Stand mit dem **alten** Versions-Label aus dem Titelblock. Bewusst akzeptiert: für 5 Module mit niedriger Update-Frequenz und einem definierten Maintainer-Personenkreis ist die Reibung eines Release-Gates größer als das Risiko des kurzen Mismatches.
+> **Wichtige Annahme:** Dieser Pfad rebuildet auch dann, wenn der Push eine `*.kicad_*`-Änderung enthält. Die Konvention im Repo ist, dass HW-Änderungen direkt vom Maintainer mit dem Auto-Release-Workflow nachgezogen werden — ansonsten zeigt die Live-Seite kurzzeitig den **neuen** Hardware-Stand mit dem **alten** Versions-Label aus dem Titelblock. Bewusst akzeptiert: für 5 Module mit niedriger Update-Frequenz und einem definierten Maintainer-Personenkreis ist die Reibung eines Release-Gates größer als das Risiko des kurzen Mismatches.
 
 ### Auto-Release-Workflow (`workflow_dispatch`)
 
 - Trigger: Maintainer klickt im Modul-Repo unter *Actions* auf *Auto-Release* → *Run workflow*.
+- Voraussetzungen:
+  - **Branch:** der Workflow erzwingt explizit Checkout von `main` und bricht ab, falls er gegen einen anderen Ref gestartet wird (`workflow_dispatch` erlaubt sonst beliebige Branches via UI).
+  - **Token mit Trigger-Berechtigung:** `gh release create` muss das nachgelagerte `release: published` Event tatsächlich auslösen. Der Default `GITHUB_TOKEN` aus dem Workflow tut das **nicht** (GitHub-Sicherheitsfeature gegen Workflow-Schleifen). Der Auto-Release-Workflow nutzt daher ein dediziertes Token (PAT oder GitHub-App-Installation-Token) aus den Org-Secrets.
 - Logik:
-  1. Letzter Release-Tag wird ermittelt. Der Filter berücksichtigt nur Tags, die **dem Schema `v<MAJOR>.<MINOR>` folgen** *und* **deren MAJOR ≥ 1** ist. Pre-Scheme-Tags wie `v0.9` oder Beta-Tags fallen durch — selbst wenn sie syntaktisch passen, gelten sie als Pre-Baseline. Praktisch: das erste vom Workflow akzeptierte Release ist immer `v1.0`.
+  1. Letzter Release-Tag wird ermittelt. Der Filter berücksichtigt nur Tags, die **dem Schema `v<MAJOR>.<MINOR>` folgen** *und* **deren MAJOR ≥ 1** ist. Pre-Scheme-Tags wie `v0.9` oder Beta-Tags fallen durch — selbst wenn sie syntaktisch passen, gelten sie als Pre-Baseline. Falls ein Modul bereits Legacy-`v1.x`-Tags von vor dieser Konvention hat, müssen diese vor dem Erst-Bootstrap entweder gelöscht werden (`gh release delete <tag> --cleanup-tag`) oder der Maintainer akzeptiert, dass der Auto-Release-Workflow ab dem höchsten existierenden `v1.x` weiterzählt. *(Für die OE5XRX-Module wurde verifiziert: keine Legacy-`v1.x`-Tags vorhanden.)*
   2. Falls **kein** Release ≥ `v1.0` existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0 --generate-notes` erzeugt; danach pickt der Auto-Release-Workflow das auf.
   3. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
   4. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
   5. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
   6. Sonst → keine Tag-Erstellung (push:main hat die Doku schon deployed).
-  7. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes.
+  7. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes (über das PAT/App-Token, damit das nachgelagerte Release-Event feuert).
 
 ### Release-Event (`release: published`)
 
@@ -81,7 +84,7 @@ flowchart TB
 - Workflow:
   1. KiBot läuft (Production-Export).
   2. `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
-  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben). Der Archive-Script ergänzt zusätzlich `nav_exclude: true` in den kopierten `*.md`-Front-Matter-Headern, damit die archivierten Seiten nicht im Just-the-docs Live-Nav als doppelte Einträge erscheinen — sie bleiben per Deep-Link erreichbar.
+  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben). Das Archive-Script ergänzt zusätzlich `nav_exclude: true` in den kopierten `*.md`-Front-Matter-Headern, damit die archivierten Seiten nicht im Just-the-docs Live-Nav als doppelte Einträge erscheinen — sie bleiben per Deep-Link erreichbar.
   4. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
   5. InvenTree-Update für die neue BOM **läuft als letzter Step und ist non-blocking** — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest (vor allem der Deploy) ist da schon durch. Reihenfolge bewusst so: ein InvenTree-Outage soll niemals das Release-Deploy blockieren.
 
@@ -126,9 +129,10 @@ Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-
 Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
 
 1. **Voraussetzung:** Maintainer mit Repo-Admin-Rechten. Das Tag-Ruleset blockiert sonst auch maintainer-getriebene Tag-Operationen. Vor dem Rollback entweder das Tag-Ruleset unter *Settings → Rules* temporär deaktivieren, oder die eigene Identität in die `Bypass list` des Rulesets aufnehmen.
-2. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
-3. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
-4. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
+2. **Source-Stand bereinigen:** der Commit, der den fehlerhaften Release ausgelöst hat, muss im Modul-Repo auf `main` zurückgenommen werden (`git revert <bad-sha>` und push, oder `git reset --hard <good-sha>` + force-push, je nach Situation). Wird das übersprungen, redeployed der nächste `push: main` denselben Bad State unter dem alten Versions-Label — und ein erneuter Auto-Release-Run würde wieder dieselbe defekte Version produzieren.
+3. Release **und** Git-Tag löschen: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag ist wichtig — sonst bleibt der Git-Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
+4. Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v1/` per `git` im OE5XRX.github.io-Repo.
+5. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
 
 ## Cross-Repo-Kompatibilität
 
@@ -162,7 +166,7 @@ Faustregeln — der Auto-Release-Workflow erkennt das alles automatisch, sie die
 
 ### Erste Releases
 
-Jedes Modul startet mit Tag `v1.0`, unabhängig davon, welche älteren Tags davor existierten (frühere Tags bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf das `v<MAJOR>.<MINOR>`-Schema mit `MAJOR ≥ 1`, sodass Pre-Scheme-Tags die Versions-Berechnung nicht durcheinander bringen). Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
+Jedes Modul startet mit Tag `v1.0`. Pre-Scheme-Tags im `v0.x`- oder Beta-Bereich bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf `MAJOR ≥ 1` und überspringt sie. Sollte ein Modul **bereits** Legacy-`v1.x`-Tags von vor dieser Konvention haben, gibt es zwei Optionen: (a) die Legacy-Tags vor dem Bootstrap löschen (`gh release delete <tag> --cleanup-tag`), oder (b) den nächsten Tag manuell auf den nächsten freien `v<MAJOR>.<MINOR>`-Slot setzen und den Auto-Release ab da weiterzählen lassen. Für die OE5XRX-Module wurde vor Rollout verifiziert, dass keine Legacy-`v1.x`-Tags existieren. Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Danach übernimmt der Auto-Release-Workflow.
 
 ### Auf welcher Seite wird das jeweils sichtbar?
 

--- a/docs/remote-station/hardware/versioning.md
+++ b/docs/remote-station/hardware/versioning.md
@@ -2,195 +2,79 @@
 title: Versioning & Releases
 nav_order: 99
 parent: Hardware
-description: Versions-Schema, Release-Workflow und Archive-Strategie für die OE5XRX-Hardware-Module.
+description: Wie die OE5XRX-Hardware-Module versioniert und released werden — Kurzüberblick.
 ---
 
 # Versioning & Releases
 
-Diese Seite beschreibt das Versions-Schema, den Release-Workflow und die Archive-Strategie der OE5XRX-Hardware-Module ([PowerBoard](./HW-Module-PowerBoard/), [BusBoard](./HW-Module-BusBoard/), [CM4 Carrier](./HW-Module-CM4Carrier/), [FM Transceiver](./HW-Module-FMTransceiver/), [DeviceTester](./HW-Module-DeviceTester/)).
-
-> **Status (Mai 2026): Konzept — Implementierung in Arbeit.** Diese Seite dokumentiert das geplante Verhalten. Phase 1 (diese Doku) ist live. Der `<<VERSION>>`-Platzhalter (Phase 2-3) ist in [`HW-Module-CI`](https://github.com/OE5XRX/HW-Module-CI) und den fünf Modul-Repos eingezogen. Der Auto-Release-Workflow (Phase 4-5) und die ersten `v1.0`-Releases (Phase 7) folgen — bis dahin behandelt CI jeden `push: main` als Doku-Update mit injiziertem `pre-release`-Label. Maintainer **nicht** vor Phase 7 ein Tag-Ruleset aktivieren (Phase 6), das blockt sonst den manuellen `v1.0`-Bootstrap.
+Wie wir die Hardware-Module ([PowerBoard](./HW-Module-PowerBoard/), [BusBoard](./HW-Module-BusBoard/), [CM4 Carrier](./HW-Module-CM4Carrier/), [FM Transceiver](./HW-Module-FMTransceiver/), [DeviceTester](./HW-Module-DeviceTester/)) versionieren — die Idee in einer Doku-Seite, nicht die Implementierung im Detail.
 
 ## Versions-Schema
 
-Jedes Modul verwendet **2-Level Semantic Versioning**: `v<MAJOR>.<MINOR>`. Es gibt **kein PATCH-Level**.
+Jedes Modul nutzt `v<MAJOR>.<MINOR>` — bewusst nur 2 Stellen, kein Patch-Level. Hardware bekommt selten kleine Bugfixes, dafür aber Re-Routes und Komponenten-Tauschs:
 
-| Bump | Was hat sich geändert | Beispiel |
-| ---- | --------------------- | -------- |
-| **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` ändert sich im Source — egal ob Re-Routing, Footprint-Tausch, Pad-Korrektur, Silkscreen-Fix oder Stecker-Pinout. Sobald sich am PCB ein Byte ändert, wird ein neuer Gerber-Satz fertigbar — also Major. | Re-Routing-Iteration, neuer Steckertyp, Pin-1-Markierung verschoben |
-| **MINOR** (`v1.0 → v1.1`) | Komponenten-Austausch ohne PCB-Layout-Änderung — `*.kicad_sch` ändert sich, `*.kicad_pcb` bleibt im Source **byte-identisch**. BOM und Schaltplan dürfen sich ändern. | LDO durch pin-kompatiblen Ersatztyp ersetzt |
-| **kein Tag** (push:main) | Nur Dokumentation, README, Workflows, CI-Konfig — keine `*.kicad_pcb`/`*.kicad_sch`-Änderung | Tippfehler in `doc/index.md`, neue Bringup-Schritte hinzugefügt |
+| Bump | Auslöser | Beispiel |
+| ---- | -------- | -------- |
+| **MAJOR** (`v1.x → v2.0`) | `*.kicad_pcb` im Source ändert sich | Re-Routing, neuer Stecker, Pad/Silkscreen-Fix |
+| **MINOR** (`v1.0 → v1.1`) | Nur `*.kicad_sch` ändert sich, PCB-Layout bleibt | LDO durch pin-kompatiblen Ersatz |
+| **kein Release** | Nur Doku, README, CI | Tippfehler in einer `index.md` |
 
-Die Bump-Entscheidung trifft ein **Auto-Release-Workflow** im jeweiligen Modul-Repo (per `workflow_dispatch` ausgelöst): er analysiert die Datei-Änderungen seit dem letzten Release-Tag und ermittelt den passenden Bump automatisch.
+Faustregel: sobald das PCB ein neues Gerber-File produziert, ist das ein Major. Alles andere ist Minor oder „nur Doku".
 
-> **Hinweise zum „Byte-Identisch"-Kriterium:**
->
-> - Nur `*.kicad_pcb` und `*.kicad_sch` zählen für die Bump-Entscheidung. Andere KiCad-Projektdateien (`*.kicad_pro`, `*.kicad_prl`, `fp-info-cache`, `sym-lib-table`) werden vom Workflow ignoriert — sie betreffen nur die Entwicklungs-Sicht, nicht das Fertigungspaket.
-> - Die `<<VERSION>>`-Substitution durch CI passiert auf den **Build-Output-Files** (kopierte temporäre Files vor KiBot), niemals auf den Sources. Der Source-`.kicad_pcb` im Repo behält immer den Literal `<<VERSION>>`. Das heißt: eine reine Versions-Label-Änderung ändert weder das Source-PCB noch löst sie einen falschen Major-Bump aus.
+## Wie kommt ein Release zustande?
 
-## Release-Workflow
+1. Maintainer pusht seine Änderungen auf `main`. Jeder Push deployed automatisch die Doku samt frischer Renderings nach [oe5xrx.org/docs/remote-station/hardware/<repo>/](https://oe5xrx.org/docs/remote-station/hardware/).
+2. Will der Maintainer einen echten Release, startet er im Modul-Repo den **Auto-Release-Workflow** (per *Actions* → *Auto-Release* → *Run workflow*). Der schaut sich den Diff seit dem letzten Release an, entscheidet Major/Minor/kein Release nach der Tabelle oben und erstellt den passenden Tag plus Release-Notes.
+3. Beim neuen Release läuft KiBot, ein BOM-Sync zu InvenTree, und die fertigen Artefakte ersetzen den bisherigen Live-Stand auf der Webseite.
 
 ```mermaid
-flowchart TB
-    Push[Developer push to main]
-    Disp[Maintainer löst<br/>Auto-Release-Workflow aus]
-
-    Push --> Build1
-    Disp --> AutoCalc
-
-    subgraph BuildPath [Build-and-Deploy]
-        direction TB
-        Build1[KiBot production export]
-        Build1 --> Stencil1[Stencil PNG]
-        Stencil1 --> Jekyll1[Jekyll build]
-        Jekyll1 --> CheckMajor{Major bump?}
-        CheckMajor -->|"yes (release event)"| Archive[Copy current<br/>/HW-Module-X/<br/>→ /HW-Module-X/v&lt;old-major&gt;/<br/>excluding existing v*/ subdirs]
-        CheckMajor -->|"no"| Deploy1
-        Archive --> Deploy1[Deploy to canonical site<br/>/docs/.../HW-Module-X/]
-        Deploy1 --> InvenTree{release event?}
-        InvenTree -->|"yes"| InvenT[Update InvenTree<br/>non-blocking]
-        InvenTree -->|"no"| Done1([Done])
-        InvenT --> Done1
-    end
-
-    AutoCalc[Diff seit letztem Release-Tag] --> Decide{Was hat sich geändert?}
-    Decide -->|"nur Doku/CI"| NoTag[Kein Release nötig<br/>push:main hat Doku schon deployed]
-    Decide -->|"nur *.kicad_sch geändert<br/>(PCB unverändert)"| Minor[gh release create<br/>v&lt;X&gt;.&lt;Y+1&gt;]
-    Decide -->|"*.kicad_pcb geändert<br/>(unabhängig vom Schaltplan)"| Major[gh release create<br/>v&lt;X+1&gt;.0]
-    Minor --> Build1
-    Major --> Build1
+flowchart LR
+    Push[push main] -->|jeder Push| Deploy[Doku + Renderings<br/>nach oe5xrx.org]
+    Disp[Maintainer:<br/>Auto-Release ausführen] --> Diff{Was hat<br/>sich geändert?}
+    Diff -->|nur Doku/CI| Done([Kein Release])
+    Diff -->|nur *.kicad_sch| Minor[Minor-Bump]
+    Diff -->|*.kicad_pcb| Major[Major-Bump]
+    Minor & Major --> Tag[gh release create] --> Build[Build + Archive + Deploy]
 ```
 
-### Push auf `main` (Doku-Deploy)
+## Versions-Label am PCB
 
-- Trigger: `push: main` Event (jeder Push, egal welche Files geändert wurden)
-- Workflow: KiBot läuft (BOM/Gerbers/Renderings werden frisch erzeugt), `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit der **letzten Release-Tag-Version** befüllt, Jekyll baut die Doku, alles wird nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/` deployed.
-- **Kein** InvenTree-Update.
-- **Kein** Archive-Snapshot.
+Im KiCad-Titelblock steht der Platzhalter `<<VERSION>>`. Den ersetzt CI beim Build mit der Versionsnummer (`1.5`, ohne `v`-Prefix). Damit zeigt jedes physische PCB seine Hardware-Revision. Hat man so ein Board in der Hand, weiß man sofort welcher Doku-Stand passt:
 
-> **Wichtige Annahme:** Dieser Pfad rebuildet auch dann, wenn der Push eine `*.kicad_*`-Änderung enthält. Die Konvention im Repo ist, dass HW-Änderungen direkt vom Maintainer mit dem Auto-Release-Workflow nachgezogen werden — ansonsten zeigt die Live-Seite kurzzeitig den **neuen** Hardware-Stand mit dem **alten** Versions-Label aus dem Titelblock. Bewusst akzeptiert: für 5 Module mit niedriger Update-Frequenz und einem definierten Maintainer-Personenkreis ist die Reibung eines Release-Gates größer als das Risiko des kurzen Mismatches.
-
-### Auto-Release-Workflow (`workflow_dispatch`)
-
-- Trigger: Maintainer klickt im Modul-Repo unter *Actions* auf *Auto-Release* → *Run workflow*.
-- Voraussetzungen:
-  - **Branch:** der Workflow erzwingt explizit Checkout von `main` und bricht ab, falls er gegen einen anderen Ref gestartet wird (`workflow_dispatch` erlaubt sonst beliebige Branches via UI).
-  - **Token mit Trigger-Berechtigung:** `gh release create` muss das nachgelagerte `release: published` Event tatsächlich auslösen. Der Default `GITHUB_TOKEN` aus dem Workflow tut das **nicht** (GitHub-Sicherheitsfeature gegen Workflow-Schleifen). Der Auto-Release-Workflow nutzt daher ein dediziertes Token (PAT oder GitHub-App-Installation-Token) aus den Org-Secrets.
-- Logik:
-  1. Letzter Release-Tag wird ermittelt. Der Filter berücksichtigt nur Tags, die **dem Schema `v<MAJOR>.<MINOR>` folgen** *und* **deren MAJOR ≥ 1** ist. Pre-Scheme-Tags wie `v0.9` oder Beta-Tags fallen durch — selbst wenn sie syntaktisch passen, gelten sie als Pre-Baseline. Falls ein Modul bereits Legacy-`v1.x`-Tags von vor dieser Konvention hat, müssen diese vor dem Erst-Bootstrap entweder gelöscht werden (`gh release delete <tag> --cleanup-tag`) oder der Maintainer akzeptiert, dass der Auto-Release-Workflow ab dem höchsten existierenden `v1.x` weiterzählt. *(Für die OE5XRX-Module wurde verifiziert: keine Legacy-`v1.x`-Tags vorhanden.)*
-  2. Falls **kein** Release ≥ `v1.0` existiert (Erst-Bootstrap) → Workflow wird abgebrochen mit einem Hinweis. Das erste `v1.0` wird vom Maintainer manuell per `gh release create v1.0 --generate-notes` erzeugt; danach pickt der Auto-Release-Workflow das auf.
-  3. Diff vom letzten Release-Tag bis `HEAD` wird auf Dateien geprüft.
-  4. Falls `*.kicad_pcb` geändert → nächster Tag wird **Major-Bump** (`v<X+1>.0`).
-  5. Sonst falls `*.kicad_sch` geändert → nächster Tag wird **Minor-Bump** (`v<X>.<Y+1>`).
-  6. Sonst → keine Tag-Erstellung (push:main hat die Doku schon deployed).
-  7. Bei Tag-Erstellung: `gh release create` mit automatisch generierten Release-Notes (über das PAT/App-Token, damit das nachgelagerte Release-Event feuert).
-
-### Release-Event (`release: published`)
-
-- Trigger: jeder neue Release im Modul-Repo — sowohl die vom Auto-Release-Workflow erzeugten Tags **als auch** der manuelle `v1.0`-Bootstrap-Release. Beide Pfade laufen denselben Build-and-Deploy-Code, sodass auch die initiale `v1.0` die dokumentierte Versions-Injection und den Deploy-Pfad erhält.
-- Workflow:
-  1. KiBot läuft (Production-Export).
-  2. `<<VERSION>>`-Platzhalter im PCB- und/oder Schaltplan-Titelblock wird mit dem **neuen Release-Tag** befüllt (Tag ohne `v`-Prefix, z.B. `1.5`).
-  3. Bei **Major-Bump**: aktuelle `/HW-Module-X/`-Ordner-Inhalte werden auf `/HW-Module-X/v<old-major>/` kopiert (Archive-Snapshot), bevor der neue Stand deployed wird. Bestehende `v*/`-Archive-Unterordner werden vom Snapshot **ausgeschlossen**, sodass keine verschachtelten Archive (`v2/v1/`) entstehen. Existiert der Archive-Pfad bereits, wird das Kopieren übersprungen (Schutz vor versehentlichem Überschreiben). Das Archive-Script ergänzt zusätzlich `nav_exclude: true` in den kopierten `*.md`-Front-Matter-Headern, damit die archivierten Seiten nicht im Just-the-docs Live-Nav als doppelte Einträge erscheinen — sie bleiben per Deep-Link erreichbar.
-  4. Deploy nach `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
-  5. InvenTree-Update für die neue BOM **läuft als letzter Step und ist non-blocking** — falls InvenTree down ist, schlägt nur dieser Step fehl, der Rest (vor allem der Deploy) ist da schon durch. Reihenfolge bewusst so: ein InvenTree-Outage soll niemals das Release-Deploy blockieren.
-
-## Titelblock-Versions-Injection
-
-Jedes KiCad-Projekt enthält im Titelblock den Platzhalter `<<VERSION>>` — je nach Modul im Schaltplan-Titelblock, im PCB-Titelblock (Silkscreen-Layer) oder in beidem (siehe `git grep '<<VERSION>>'` im jeweiligen Modul-Repo). Beim Build wird der Platzhalter ersetzt:
-
-| Trigger | Was wird in `<<VERSION>>` injiziert |
-| ------- | ----------------------------------- |
-| Tagged Release (`release: published`) | Tag-Name ohne `v`-Prefix, z.B. `1.5` |
-| Push auf `main` (zwischen Releases) | Letzter Release-Tag ohne `v`-Prefix, z.B. `1.5` |
-| Push auf `main` bevor je ein Release gemacht wurde | Literal `pre-release` (Ausnahme: nicht semver-konform; markiert nur den Bootstrap-Zustand vor dem ersten `v1.0`) |
-
-Konsequenz: **das PCB zeigt die Hardware-Version**, nicht den momentanen Doku-Stand. Wenn du ein physisches PCB mit `1.5` gedruckt in der Hand hast, findest du den passenden Modul-Stand zur Hardware-Revision so:
-
-- Falls `1.5` zur **aktuell** auf der Webseite veröffentlichten Major-Version (`v1.x`) gehört → kanonische Doku unter `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`.
-- Falls `1.5` zu einer **älteren** Major-Version gehört (z.B. live ist v2 oder neuer) → Archiv-Doku unter `https://oe5xrx.org/docs/remote-station/hardware/<repo>/v1/`.
-
-Die kanonische URL zeigt also **immer den aktuellen Major** — historische Hardware findet sich in den `v<old-major>/`-Archiven.
+- **Aktueller Major** → kanonische Doku unter `oe5xrx.org/docs/remote-station/hardware/<repo>/`
+- **Älterer Major** → archivierte Doku unter `…/<repo>/v1/`, `…/<repo>/v0/` etc.
 
 ## Archive-Strategie
 
-Auf `https://oe5xrx.org/docs/remote-station/hardware/<repo>/`:
+Beim Major-Bump (z.B. `v1.x → v2.0`) verschiebt CI den bisherigen `/<repo>/`-Inhalt auf `/<repo>/v1/`. Danach landet der neue v2-Stand im Wurzelverzeichnis. Minor-Bumps und reine Doku-Pushes lassen die Archive in Ruhe.
 
-```
-docs/remote-station/hardware/HW-Module-PowerBoard/
-├── (aktueller Major, z.B. v2.x)
-├── v1/       ← Snapshot des letzten v1.x-Stands (eingefroren als v2.0 released wurde)
-└── v0/       ← Snapshot des letzten v0.x-Stands (falls je vorhanden)
-```
-
-Regeln:
-
-- Beim **Major-Bump** wird der aktuelle Stand snapshot-kopiert nach `/v<old-major>/`, bevor der neue Stand das Wurzelverzeichnis überschreibt. Bestehende `v*/`-Unterordner sind vom Snapshot ausgeschlossen.
-- Bei **Minor-Bumps** und **push:main** bleibt nur das Wurzelverzeichnis aktualisiert; vorhandene Archive bleiben unverändert.
-- Existiert der Archive-Pfad bereits, wird **nicht** überschrieben (Schutz vor versehentlichem Doppel-Trigger oder Re-Release).
-
-## Manuelle Releases / Tag-Pushes
-
-Manuelle Tag-Pushes durch Maintainer sind **nicht vorgesehen** (außer dem Erst-Bootstrap auf `v1.0`). Der Auto-Release-Workflow ist die einzige unterstützte Methode danach. In den Repository-Settings unter **Rules → Rulesets** sollte ein Tag-Ruleset aktiviert werden, das Tag-Pushes nur für **die konkrete Identität erlaubt, unter der `gh release create` im Auto-Release-Workflow läuft** — also typischerweise der PAT-Owner oder die GitHub-App-Installation, deren Token in den Org-Secrets liegt. Eine generische „GitHub Actions" Allow-Rule reicht nicht, weil der PAT-Push als Identität des PAT-Owners zählt, nicht als Bot. *(GitHub hat die alten Tag-Protection-Rules Ende 2024 durch Rulesets ersetzt.)*
-
-> **Reihenfolge wichtig:** Das Tag-Ruleset **erst nach dem manuellen `v1.0`-Bootstrap** aktivieren (Phase 6 nach Phase 7). Ein vorher aktiviertes Ruleset blockt sonst den Bootstrap-Push selbst. Für etwaige spätere `v1.0`-Bootstraps weiterer Module gilt: vorher das Ruleset temporär deaktivieren oder die eigene Identität in die `Bypass list` aufnehmen.
-
-Notfall-Korrekturen (z.B. fehlerhaftes Release rollbacken) verlaufen manuell:
-
-1. **Voraussetzung:** Maintainer mit Repo-Admin-Rechten. Das Tag-Ruleset blockiert sonst auch maintainer-getriebene Tag-Operationen. Vor dem Rollback entweder das Tag-Ruleset unter *Settings → Rules* temporär deaktivieren, oder die eigene Identität in die `Bypass list` des Rulesets aufnehmen.
-2. **Source-Stand bereinigen:** der Commit, der den fehlerhaften Release ausgelöst hat, muss im Modul-Repo auf `main` zurückgenommen werden (`git revert <bad-sha>` und push, oder `git reset --hard <good-sha>` + force-push, je nach Situation). Wird das übersprungen, redeployed der nächste `push: main` denselben Bad State unter dem alten Versions-Label — und ein erneuter Auto-Release-Run würde wieder dieselbe defekte Version produzieren.
-3. Release **und** Git-Tag löschen:
-    - Falls ein Release-Objekt existiert: `gh release delete v2.0 --cleanup-tag` (das `--cleanup-tag`-Flag entfernt zusätzlich den Git-Tag — ohne den Flag bleibt der Tag bestehen und der Auto-Release-Workflow zählt von ihm aus weiter).
-    - Falls **nur** ein raw Git-Tag existiert (z.B. Legacy-`v1.x`-Cleanup vor dem Bootstrap, hier ohne zugehörigen GitHub-Release): `git tag -d v2.0 && git push origin :refs/tags/v2.0`. `gh release delete` schlägt sonst mit „release not found" fehl.
-4. **Failed-Archive löschen:** falls beim Major-Bump-Versuch bereits ein `/v<failed-major>/`-Snapshot angelegt wurde, diesen vor dem Restore entfernen — sonst überspringt der nächste Versuch das Archive (Existence-Guard) und das Wurzelverzeichnis bekommt keinen sauberen Vorgänger-Snapshot.
-5. **Restore:** Wiederherstellung der `/HW-Module-X/`-Inhalte aus `/v<good-major>/` per `git` im OE5XRX.github.io-Repo. Beim Promoten zurück zur Live-Position das `nav_exclude: true` aus den `*.md`-Front-Matter-Headern entfernen — sonst ist die wiederhergestellte Doku zwar live, aber nicht im Just-the-docs Nav-Tree sichtbar.
-6. Tag-Ruleset wieder aktivieren bzw. Bypass entfernen.
+Konsequenz: die aktuelle Major-Version ist immer einen Klick weniger entfernt; ältere Hardware-Revisionen bleiben aber dauerhaft erreichbar — wichtig, wenn jemand ein „altes" Board aus dem Schrank holt.
 
 ## Cross-Repo-Kompatibilität
 
-Die Modul-Versionen sind **unabhängig** voneinander. PowerBoard `v1.5` und BusBoard `v2.0` haben keine implizite Kopplung — jedes Modul versioniert eigenständig.
+Jedes Modul versioniert eigenständig. PowerBoard `v1.5` und BusBoard `v2.0` haben keine implizite Kopplung. Falls eine Modul-Version eine andere nicht mehr unterstützt, steht das in der `doc/index.md` des betreffenden Moduls — keine zentrale Compatibility-Matrix, jedes Modul-Doc spricht für sich.
 
-Falls eine Modul-Version eine andere Modul-Version explizit nicht mehr unterstützt, wird das **in der `doc/index.md` des Moduls** dokumentiert (z.B. *PowerBoard v2.0 erfordert BusBoard ≥ v1.5 wegen erhöhter Stromleitfähigkeit*). Es gibt keine zentrale Compatibility-Matrix — jedes Modul-Doc spricht für sich.
+## Firmware ist anders
 
-## Firmware-Versionen
+Die STM32-Firmware im FM-Modul lebt in [`FW-RemoteStation`](https://github.com/OE5XRX/FW-RemoteStation) und nutzt **3-Stellen-Semver** (`v1.2.3`). Firmware kriegt regelmäßig Patches, Hardware nicht — daher die unterschiedlichen Schemas.
 
-Die STM32-Firmware im FM-Modul wird in einem **eigenen Repo** ([`FW-RemoteStation`](https://github.com/OE5XRX/FW-RemoteStation)) versioniert — ebenfalls Semver, aber **mit 3 Stellen** (`v1.2.3`), weil Firmware Patches anders behandelt als Hardware-Module.
+## Faustregeln für Maintainer
 
-Bei Firmware-Releases, die ein bestimmtes Hardware-Modul nicht mehr unterstützen, wird das in den FM-Modul-Docs vermerkt (z.B. *FW ≥ v2.0.0 setzt FM-Modul ≥ v1.5 voraus*).
+Was du wann erwarten kannst:
 
-## Operative Hinweise für Maintainer
+- **Tippfehler in der Doku gefixt** → push, Auto-Deploy, kein Release.
+- **Kondensator durch pin-kompatiblen Ersatz getauscht** → Minor.
+- **PCB neu geroutet, neue Power-Plane** → Major.
+- **Pin-1-Markierung im Silkscreen verschoben** → Major. Auch wenn's optisch wirkt: für die Fertigung ist es ein neuer Gerber-Satz.
 
-### Wann was bumpen?
+Beim allerersten Release legt der Maintainer den Tag `v1.0` selbst per `gh release create v1.0 --generate-notes` an — danach übernimmt der Auto-Release-Workflow. Manuelle Tag-Pushes sind sonst nicht vorgesehen.
 
-Faustregeln — der Auto-Release-Workflow erkennt das alles automatisch, sie dienen nur zur Vorab-Orientierung:
-
-- **Ich möchte nur einen Tippfehler in der Doku fixen.**
-  → Push auf `main`. Auto-Deploy. Kein Release.
-
-- **Ich habe einen Kondensatortyp durch einen pin-kompatiblen Alternativ-Hersteller ersetzt.**
-  → `*.kicad_sch` ändert sich, `*.kicad_pcb` Layout bleibt byte-identisch. Auto-Release ergibt **Minor**.
-
-- **Ich habe das PCB neu geroutet (nach DRC-Cleanup, neuer Power-Plane).**
-  → `*.kicad_pcb` ändert sich. Auto-Release ergibt **Major**.
-
-- **Ich habe einen kosmetischen Silkscreen-Fix (z.B. Pin-1-Markierung) gemacht.**
-  → `*.kicad_pcb` ändert sich (Silkscreen-Layer ist Teil der Gerber-Daten). Auto-Release ergibt **Major** — und das ist auch richtig so: für die Fertigung ändert sich der Datensatz, der ans PCB-House geht. Lass das Release durch.
-
-### Erste Releases
-
-Jedes Modul startet mit Tag `v1.0`. Pre-Scheme-Tags im `v0.x`- oder Beta-Bereich bleiben im Repo erhalten, werden aber nicht weiter gepflegt — der Auto-Release-Workflow filtert auf `MAJOR ≥ 1` und überspringt sie. Sollte ein Modul **bereits** Legacy-`v1.x`-Tags von vor dieser Konvention haben, gibt es zwei Optionen:
-
-- **(a) Legacy-Tags vor dem Bootstrap löschen.** Wenn zum Tag ein GitHub-Release existiert: `gh release delete <tag> --cleanup-tag`. Wenn es nur einen raw Git-Tag ohne Release-Objekt gibt: `git tag -d <tag> && git push origin :refs/tags/<tag>` — `gh release delete` schlägt sonst mit „release not found" fehl.
-- **(b) Den ersten Bootstrap-Tag auf den nächsten freien `v<MAJOR>.<MINOR>`-Slot setzen** und den Auto-Release ab da weiterzählen lassen.
-
-Für die OE5XRX-Module wurde vor Rollout verifiziert, dass keine Legacy-`v1.x`-Tags existieren. Pro Modul entscheidet der Maintainer, wann das erste `v1.0` released wird — und legt diesen ersten Tag manuell an (`gh release create v1.0 --generate-notes`). Das Tag-Ruleset darf zu diesem Zeitpunkt **nicht** aktiv sein, sonst blockt es den Bootstrap-Push (siehe „Manuelle Releases / Tag-Pushes" oben). Nach dem ersten Release übernimmt der Auto-Release-Workflow.
-
-### Auf welcher Seite wird das jeweils sichtbar?
+## Wo siehst du welche Version?
 
 | Stelle | Was wird gezeigt |
 | ------ | ---------------- |
 | `oe5xrx.org/docs/remote-station/hardware/<repo>/` | Aktuelle Major-Version |
-| `oe5xrx.org/docs/remote-station/hardware/<repo>/v1/` etc. | Archivierte Major-Versionen |
-| `github.com/OE5XRX/<repo>/releases` | Alle bisherigen Tags + Release-Notes |
-| Auf dem physischen PCB (Titelblock) | Hardware-Version (Major.Minor, ohne v) |
+| `…/<repo>/v1/`, `…/v0/` etc. | Archivierte Major-Versionen |
+| `github.com/OE5XRX/<repo>/releases` | Alle Tags + Release-Notes |
+| PCB-Titelblock (Silkscreen) | Hardware-Version (`MAJOR.MINOR`, ohne `v`) |
 | InvenTree | BOM pro Release-Tag |


### PR DESCRIPTION
## Summary

- Neue Seite `docs/remote-station/hardware/versioning.md` als zentrale Referenz für das Versions- und Release-Konzept der `HW-Module-*`-Repos.
- Dokumentiert **2-Level Semver** (`v<MAJOR>.<MINOR>`, kein Patch-Level), Auto-Release per `workflow_dispatch`, Major-Archive auf der Webseite, `<<VERSION>>`-Platzhalter-Injection ins PCB-Titelblock, und Notfall-Rollback-Prozedur.
- Anker für künftige `doc/index.md`-Querverweise aus den Modul-Repos (z.B. „PowerBoard v2.0 erfordert BusBoard ≥ v1.5").

## Was hier dokumentiert wird (kurz)

| Trigger | Bump | Was passiert |
| ------- | ---- | ------------ |
| `*.kicad_pcb` geändert | **Major** (`vX.0`) | Archive-Snapshot des alten Stands, neues Deploy, InvenTree-Update |
| `*.kicad_sch` geändert | **Minor** (`vX.Y+1`) | Neues Deploy, InvenTree-Update |
| Nur Doku/CI geändert | **kein Tag** | `push:main` deployed Doku ohne Release |

## Phase 1 von 7 — Release-Konzept

Diese Seite ist Phase 1 der Implementierung. Folgende Phasen kommen separat (eigene PRs in den HW-Module-CI / Module-Repos):

- Phase 2: `<<HASH>>` → `<<VERSION>>` Konvention in HW-Module-CI Workflows
- Phase 3: Platzhalter-Migration in den 5 Modul-Schaltplänen
- Phase 4: Auto-Release-Workflow (`workflow_dispatch`, computed-next-version, `gh release create`)
- Phase 5: Release-Docs-Workflow Rebuild (Version-Injection, Conditional InvenTree, Major-Archive mit Existence-Guard)
- Phase 6 (optional): Tag Protection Rules
- Phase 7: Erste `v1.0`-Releases — User-getriggert, ein Modul nach dem anderen

## Test plan

- [ ] Jekyll-Build lokal/CI grün
- [ ] Mermaid-Diagramm rendert korrekt auf der Live-Seite
- [ ] Link-Anker funktionieren (`#cm4-flashen` etc. in den Modul-Docs noch korrekt)
- [ ] `nav_order: 99` setzt die Seite ans Ende der Hardware-Section

🤖 Generated with [Claude Code](https://claude.com/claude-code)